### PR TITLE
Add REST API v1 for AI agent access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ GOOGLE_CLIENT_SECRET=your-google-oauth-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:5173/api/auth/callback
 PUBLIC_SPACETIMEDB_MODULE=
 PUBLIC_SPACETIMEDB_URI=wss://maincloud.spacetimedb.com
+API_KEYS=sk-agent-your-key-here

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ Copy the example file and fill in your credentials:
 cp .env.example .env
 ```
 
-| Variable               | Description                    | Required |
-| ---------------------- | ------------------------------ | -------- |
-| `GOOGLE_CLIENT_ID`     | Google OAuth 2.0 Client ID     | Yes      |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth 2.0 Client Secret | Yes      |
-| `PUBLIC_SPACETIMEDB_MODULE` | Database name   | Yes      |
-| `PUBLIC_SPACETIMEDB_URI` | Database cluster   | Yes      |
+| Variable                    | Description                                  | Required |
+| --------------------------- | -------------------------------------------- | -------- |
+| `GOOGLE_CLIENT_ID`          | Google OAuth 2.0 Client ID                   | Yes      |
+| `GOOGLE_CLIENT_SECRET`      | Google OAuth 2.0 Client Secret               | Yes      |
+| `PUBLIC_SPACETIMEDB_MODULE` | Database name                                | Yes      |
+| `PUBLIC_SPACETIMEDB_URI`    | Database cluster                             | Yes      |
+| `API_KEYS`                  | Comma-separated API keys for REST API access | No       |
 
 ## Project Structure
 
@@ -87,6 +88,13 @@ docker compose down
 ```
 
 The compose file reads credentials from your `.env` file and defaults `ORIGIN` to `http://localhost:3000` if not set.
+
+## REST API
+
+A REST API (`/api/v1`) is available for AI agent and programmatic access. Authentication is via Bearer token — set the `API_KEYS` environment variable with one or more comma-separated keys.
+
+- **AI agent guidance**: [`/llms.txt`](public/llms.txt) — plain-language overview and workflow tips
+- **OpenAPI spec**: [`/openapi.json`](public/openapi.json) — machine-readable specification for tool generation
 
 ### Production Checklist
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "typescript-eslint": "8.38.0",
         "typescript-plugin-css-modules": "latest",
         "vite": "7.3.1",
-        "vite-tsconfig-paths": "^4.2.1"
+        "vite-tsconfig-paths": "^4.2.1",
+        "vitest": "^4.1.2"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1628,6 +1629,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -2449,6 +2457,24 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2458,6 +2484,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3326,6 +3359,119 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abbrev": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -3546,6 +3692,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3890,6 +4046,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4047,6 +4213,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -4601,6 +4774,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5056,6 +5236,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -6735,6 +6925,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -8061,6 +8261,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -8245,6 +8456,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/peek-stream": {
       "version": "1.1.3",
@@ -9405,6 +9623,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -9564,6 +9789,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -9572,6 +9804,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -9835,6 +10074,23 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -9850,6 +10106,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -10637,6 +10903,88 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10739,6 +11087,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "dev.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js --mode ssr --force",
     "fmt": "prettier --write .",
     "fmt.check": "prettier --check .",
+    "test": "vitest run",
+    "test.watch": "vitest",
     "lint": "eslint \"src/**/*.ts*\"",
     "preview": "qwik build preview && vite preview --open",
     "start": "vite --open --mode ssr",
@@ -38,7 +40,8 @@
     "typescript-eslint": "8.38.0",
     "typescript-plugin-css-modules": "latest",
     "vite": "7.3.1",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^4.1.2"
   },
   "dependencies": {
     "@fastify/compress": "^8.3.1",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,49 @@
+# Parking Reservation API
+
+> Office parking spot reservation system with REST API for AI agent access.
+
+## Overview
+
+This is a web app for reserving office parking spots. The REST API (v1) allows AI agents and scripts to check availability, make reservations, and cancel them programmatically.
+
+All API endpoints require authentication via a Bearer token in the `Authorization` header.
+
+## Authentication
+
+Include your API key in every request:
+
+    Authorization: Bearer <your-api-key>
+
+Keys are provisioned by the server administrator via the `API_KEYS` environment variable.
+
+## API Base URL
+
+    /api/v1
+
+## Typical Workflow
+
+1. **Check availability**: `GET /api/v1/spots?date=2025-06-15` to see which spots are free.
+2. **Reserve a spot**: Either pick a specific spot with `POST /api/v1/reservations`, or let the system auto-assign one with `POST /api/v1/reservations/quick`.
+3. **Cancel if needed**: `DELETE /api/v1/reservations` with the same spotId, date, and occupant.
+
+## Endpoints
+
+- `GET /api/v1/spots?date=YYYY-MM-DD` — List all spots with availability status for a date.
+- `GET /api/v1/reservations?date=YYYY-MM-DD` — List all reservations for a date.
+- `POST /api/v1/reservations` — Reserve a specific spot. Body: `{ "spotId": 1, "date": "YYYY-MM-DD", "occupant": "Name" }`.
+- `DELETE /api/v1/reservations` — Cancel a reservation. Body: same as POST.
+- `POST /api/v1/reservations/quick` — Auto-assign the first available spot. Body: `{ "date": "YYYY-MM-DD", "occupant": "Name" }`.
+
+## Tips
+
+- Use the **quick reserve** endpoint when you don't need a specific spot — it's simpler and avoids conflicts.
+- Dates must be in **YYYY-MM-DD** format (e.g. `2025-06-15`).
+- The **occupant** field is typically a person's name. Whitespace is trimmed.
+- A **409 Conflict** response means a business logic issue: spot already taken, no free spots, or occupant mismatch on cancel.
+- The `spotId` and `spotName` in the quick reserve response may be `null` if the server couldn't confirm the assignment in time — the reservation still succeeded.
+
+## API Specification
+
+For the full machine-readable API spec (request/response schemas, error codes):
+
+> [OpenAPI Specification](/openapi.json)

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,374 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Parking Reservation API",
+    "version": "1.0.0",
+    "description": "REST API for managing office parking spot reservations. Designed for AI agent and programmatic access."
+  },
+  "servers": [
+    {
+      "url": "/api/v1",
+      "description": "API v1"
+    }
+  ],
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
+  "paths": {
+    "/spots": {
+      "get": {
+        "operationId": "listSpots",
+        "summary": "List parking spots with availability for a date",
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2025-06-15"
+            },
+            "description": "Date in YYYY-MM-DD format"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Spots with availability",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "date": { "type": "string" },
+                    "spots": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SpotWithAvailability"
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "Total number of spots"
+                    },
+                    "available": {
+                      "type": "integer",
+                      "description": "Number of free spots"
+                    }
+                  },
+                  "required": ["date", "spots", "total", "available"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/reservations": {
+      "get": {
+        "operationId": "listReservations",
+        "summary": "List all reservations for a date",
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "example": "2025-06-15"
+            },
+            "description": "Date in YYYY-MM-DD format"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reservations for the date",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "date": { "type": "string" },
+                    "reservations": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Reservation" }
+                    },
+                    "count": { "type": "integer" }
+                  },
+                  "required": ["date", "reservations", "count"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      },
+      "post": {
+        "operationId": "createReservation",
+        "summary": "Reserve a specific parking spot",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ReservationRequest" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Reservation created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "const": true },
+                    "spotId": { "type": "integer" },
+                    "spotName": { "type": ["string", "null"] },
+                    "date": { "type": "string" },
+                    "occupant": { "type": "string" }
+                  },
+                  "required": [
+                    "success",
+                    "spotId",
+                    "spotName",
+                    "date",
+                    "occupant"
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "409": { "$ref": "#/components/responses/Conflict" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      },
+      "delete": {
+        "operationId": "cancelReservation",
+        "summary": "Cancel a reservation",
+        "description": "The occupant must match the original reservation holder.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ReservationRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Reservation cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "const": true },
+                    "spotId": { "type": "integer" },
+                    "date": { "type": "string" }
+                  },
+                  "required": ["success", "spotId", "date"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "409": { "$ref": "#/components/responses/Conflict" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/reservations/quick": {
+      "post": {
+        "operationId": "quickReserve",
+        "summary": "Auto-assign the first available spot",
+        "description": "Automatically picks a free spot for the given date. Use this when you don't care which specific spot is assigned.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "date": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "description": "Date in YYYY-MM-DD format",
+                    "example": "2025-06-15"
+                  },
+                  "occupant": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Name of the person reserving",
+                    "example": "Alice"
+                  }
+                },
+                "required": ["date", "occupant"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Spot auto-assigned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "const": true },
+                    "date": { "type": "string" },
+                    "occupant": { "type": "string" },
+                    "spotId": {
+                      "type": ["integer", "null"],
+                      "description": "May be null if data sync timed out"
+                    },
+                    "spotName": {
+                      "type": ["string", "null"],
+                      "description": "May be null if data sync timed out"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "date",
+                    "occupant",
+                    "spotId",
+                    "spotName"
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "409": { "$ref": "#/components/responses/Conflict" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "API key passed as a Bearer token. Obtain your key from the server administrator."
+      }
+    },
+    "schemas": {
+      "SpotWithAvailability": {
+        "type": "object",
+        "properties": {
+          "spotId": {
+            "type": "integer",
+            "description": "Unique spot identifier"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable spot name (e.g. \"A1\")"
+          },
+          "occupant": {
+            "type": ["string", "null"],
+            "description": "Name of person occupying the spot, or null if free"
+          },
+          "available": {
+            "type": "boolean",
+            "description": "Whether the spot is free to reserve"
+          }
+        },
+        "required": ["spotId", "name", "occupant", "available"]
+      },
+      "Reservation": {
+        "type": "object",
+        "properties": {
+          "spotId": { "type": "integer" },
+          "spotName": {
+            "type": ["string", "null"],
+            "description": "Spot name, or null if spot was deleted"
+          },
+          "occupant": { "type": "string" }
+        },
+        "required": ["spotId", "spotName", "occupant"]
+      },
+      "ReservationRequest": {
+        "type": "object",
+        "properties": {
+          "spotId": {
+            "type": "integer",
+            "description": "ID of the parking spot",
+            "example": 1
+          },
+          "date": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "Date in YYYY-MM-DD format",
+            "example": "2025-06-15"
+          },
+          "occupant": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the person reserving",
+            "example": "Alice"
+          }
+        },
+        "required": ["spotId", "date", "occupant"]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string", "description": "Error category" },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error detail"
+          }
+        },
+        "required": ["error", "message"]
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Invalid input (missing fields, bad date format, invalid JSON)",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Missing or invalid API key",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "Business logic conflict (spot already reserved, no free spots, occupant mismatch)",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Unexpected server error",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/routes/api/v1/layout.test.ts
+++ b/src/routes/api/v1/layout.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/services/api-auth", () => ({
+  validateApiKey: vi.fn(),
+}));
+
+import { onRequest } from "./layout";
+import { validateApiKey } from "~/services/api-auth";
+
+const mockValidateApiKey = vi.mocked(validateApiKey);
+
+function makeRequestEvent(authHeader: string | null) {
+  const headers = new Map<string, string | null>();
+  if (authHeader !== null) {
+    headers.set("authorization", authHeader);
+  }
+
+  const event: any = {
+    request: {
+      headers: {
+        get: (name: string) =>
+          name === "Authorization" ? (authHeader ?? null) : null,
+      },
+    },
+    env: {
+      get: (key: string) => (key === "API_KEYS" ? "sk-test-key" : undefined),
+    },
+    json: vi.fn(),
+    next: vi.fn(),
+  };
+  return event;
+}
+
+describe("API v1 auth middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when validation fails", async () => {
+    mockValidateApiKey.mockReturnValue({
+      valid: false,
+      error: "Missing Authorization header",
+    });
+
+    const event = makeRequestEvent(null);
+    await onRequest(event);
+
+    expect(event.json).toHaveBeenCalledWith(401, {
+      error: "Unauthorized",
+      message: "Missing Authorization header",
+    });
+    expect(event.next).not.toHaveBeenCalled();
+  });
+
+  it("calls next() when validation succeeds", async () => {
+    mockValidateApiKey.mockReturnValue({ valid: true });
+
+    const event = makeRequestEvent("Bearer sk-test-key");
+    await onRequest(event);
+
+    expect(event.json).not.toHaveBeenCalled();
+    expect(event.next).toHaveBeenCalled();
+  });
+
+  it("passes env and auth header to validateApiKey", async () => {
+    mockValidateApiKey.mockReturnValue({ valid: true });
+
+    const event = makeRequestEvent("Bearer my-key");
+    await onRequest(event);
+
+    expect(mockValidateApiKey).toHaveBeenCalledWith(event.env, "Bearer my-key");
+  });
+});

--- a/src/routes/api/v1/layout.ts
+++ b/src/routes/api/v1/layout.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from "@builder.io/qwik-city";
+import { validateApiKey } from "~/services/api-auth";
+
+/**
+ * Auth middleware for all /api/v1/* routes.
+ * Validates the API key from the Authorization: Bearer header.
+ */
+export const onRequest: RequestHandler = async (requestEvent) => {
+  const authHeader = requestEvent.request.headers.get("Authorization");
+  const result = validateApiKey(requestEvent.env, authHeader);
+
+  if (!result.valid) {
+    requestEvent.json(401, { error: "Unauthorized", message: result.error });
+    return;
+  }
+
+  await requestEvent.next();
+};

--- a/src/routes/api/v1/reservations/index.test.ts
+++ b/src/routes/api/v1/reservations/index.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/services/spacetimedb", () => ({
+  getConnection: vi.fn(),
+  getReservationsForDate: vi.fn(),
+  getSpots: vi.fn(),
+  reserveSpot: vi.fn(),
+  cancelReservation: vi.fn(),
+}));
+
+import { onGet, onPost, onDelete } from "./index";
+import {
+  getConnection,
+  getReservationsForDate,
+  getSpots,
+  reserveSpot,
+  cancelReservation,
+} from "~/services/spacetimedb";
+
+const mockGetConnection = vi.mocked(getConnection);
+const mockGetReservationsForDate = vi.mocked(getReservationsForDate);
+const mockGetSpots = vi.mocked(getSpots);
+const mockReserveSpot = vi.mocked(reserveSpot);
+const mockCancelReservation = vi.mocked(cancelReservation);
+
+function makeGetEvent(queryParams: Record<string, string> = {}) {
+  return {
+    query: { get: (key: string) => queryParams[key] ?? null },
+    json: vi.fn(),
+  } as any;
+}
+
+function makeBodyEvent(body: any, parseError = false) {
+  return {
+    request: {
+      json: parseError
+        ? vi.fn().mockRejectedValue(new SyntaxError("bad json"))
+        : vi.fn().mockResolvedValue(body),
+    },
+    json: vi.fn(),
+  } as any;
+}
+
+describe("GET /api/v1/reservations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConnection.mockResolvedValue({} as any);
+  });
+
+  it("returns 400 when date is missing", async () => {
+    const event = makeGetEvent();
+    await onGet(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns 400 for invalid date format", async () => {
+    const event = makeGetEvent({ date: "not-a-date" });
+    await onGet(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns reservations for a valid date", async () => {
+    mockGetReservationsForDate.mockReturnValue([
+      { spotId: 1, date: "2025-06-15", occupant: "Alice" } as any,
+      { spotId: 3, date: "2025-06-15", occupant: "Bob" } as any,
+    ]);
+    mockGetSpots.mockReturnValue([
+      { id: 1, name: "A1", sortOrder: 1 } as any,
+      { id: 2, name: "A2", sortOrder: 2 } as any,
+      { id: 3, name: "B1", sortOrder: 3 } as any,
+    ]);
+
+    const event = makeGetEvent({ date: "2025-06-15" });
+    await onGet(event);
+
+    expect(event.json).toHaveBeenCalledWith(200, {
+      date: "2025-06-15",
+      reservations: [
+        { spotId: 1, spotName: "A1", occupant: "Alice" },
+        { spotId: 3, spotName: "B1", occupant: "Bob" },
+      ],
+      count: 2,
+    });
+  });
+
+  it("returns null spotName for unknown spotId", async () => {
+    mockGetReservationsForDate.mockReturnValue([
+      { spotId: 999, date: "2025-06-15", occupant: "Ghost" } as any,
+    ]);
+    mockGetSpots.mockReturnValue([]);
+
+    const event = makeGetEvent({ date: "2025-06-15" });
+    await onGet(event);
+
+    expect(event.json).toHaveBeenCalledWith(
+      200,
+      expect.objectContaining({
+        reservations: [{ spotId: 999, spotName: null, occupant: "Ghost" }],
+      }),
+    );
+  });
+});
+
+describe("POST /api/v1/reservations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConnection.mockResolvedValue({} as any);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const event = makeBodyEvent(null, true);
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(400, {
+      error: "Bad Request",
+      message: "Invalid JSON body",
+    });
+  });
+
+  it("returns 400 when spotId is missing", async () => {
+    const event = makeBodyEvent({ date: "2025-06-15", occupant: "Alice" });
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns 400 when occupant is empty", async () => {
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "  ",
+    });
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns 400 when date format is invalid", async () => {
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "15-06-2025",
+      occupant: "Alice",
+    });
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        message: "'date' must be in YYYY-MM-DD format",
+      }),
+    );
+  });
+
+  it("creates reservation successfully", async () => {
+    mockReserveSpot.mockResolvedValue(undefined);
+    mockGetSpots.mockReturnValue([{ id: 1, name: "A1", sortOrder: 1 } as any]);
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+    await onPost(event);
+
+    expect(mockReserveSpot).toHaveBeenCalledWith(1, "2025-06-15", "Alice");
+    expect(event.json).toHaveBeenCalledWith(201, {
+      success: true,
+      spotId: 1,
+      spotName: "A1",
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+  });
+
+  it("trims occupant whitespace", async () => {
+    mockReserveSpot.mockResolvedValue(undefined);
+    mockGetSpots.mockReturnValue([]);
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "  Alice  ",
+    });
+    await onPost(event);
+
+    expect(mockReserveSpot).toHaveBeenCalledWith(1, "2025-06-15", "Alice");
+  });
+
+  it("returns 409 when spot is already reserved", async () => {
+    mockReserveSpot.mockRejectedValue(new Error("Spot is already reserved"));
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+    await onPost(event);
+
+    expect(event.json).toHaveBeenCalledWith(409, {
+      error: "Conflict",
+      message: "Spot is already reserved",
+    });
+  });
+
+  it("returns 409 when spot does not exist", async () => {
+    mockReserveSpot.mockRejectedValue(new Error("Spot does not exist"));
+
+    const event = makeBodyEvent({
+      spotId: 999,
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+    await onPost(event);
+
+    expect(event.json).toHaveBeenCalledWith(409, {
+      error: "Conflict",
+      message: "Spot does not exist",
+    });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockReserveSpot.mockRejectedValue(new Error("DB down"));
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+    await onPost(event);
+
+    expect(event.json).toHaveBeenCalledWith(500, {
+      error: "Internal Server Error",
+      message: "DB down",
+    });
+  });
+});
+
+describe("DELETE /api/v1/reservations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConnection.mockResolvedValue({} as any);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const event = makeBodyEvent(null, true);
+    await onDelete(event);
+    expect(event.json).toHaveBeenCalledWith(400, {
+      error: "Bad Request",
+      message: "Invalid JSON body",
+    });
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const event = makeBodyEvent({ spotId: 1 });
+    await onDelete(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns 400 for invalid date format", async () => {
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "bad-date",
+      occupant: "Alice",
+    });
+    await onDelete(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        message: "'date' must be in YYYY-MM-DD format",
+      }),
+    );
+  });
+
+  it("cancels reservation successfully", async () => {
+    mockCancelReservation.mockResolvedValue(undefined);
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+    await onDelete(event);
+
+    expect(mockCancelReservation).toHaveBeenCalledWith(
+      1,
+      "2025-06-15",
+      "Alice",
+    );
+    expect(event.json).toHaveBeenCalledWith(200, {
+      success: true,
+      spotId: 1,
+      date: "2025-06-15",
+    });
+  });
+
+  it("returns 409 when no reservation found", async () => {
+    mockCancelReservation.mockRejectedValue(
+      new Error("No reservation found for this spot"),
+    );
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+    await onDelete(event);
+
+    expect(event.json).toHaveBeenCalledWith(409, {
+      error: "Conflict",
+      message: "No reservation found for this spot",
+    });
+  });
+
+  it("returns 409 when occupant does not match", async () => {
+    mockCancelReservation.mockRejectedValue(
+      new Error("Only Alice can cancel this reservation"),
+    );
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "Bob",
+    });
+    await onDelete(event);
+
+    expect(event.json).toHaveBeenCalledWith(409, {
+      error: "Conflict",
+      message: "Only Alice can cancel this reservation",
+    });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockCancelReservation.mockRejectedValue(new Error("Timeout"));
+
+    const event = makeBodyEvent({
+      spotId: 1,
+      date: "2025-06-15",
+      occupant: "Alice",
+    });
+    await onDelete(event);
+
+    expect(event.json).toHaveBeenCalledWith(500, {
+      error: "Internal Server Error",
+      message: "Timeout",
+    });
+  });
+});

--- a/src/routes/api/v1/reservations/index.ts
+++ b/src/routes/api/v1/reservations/index.ts
@@ -1,0 +1,152 @@
+import type { RequestHandler } from "@builder.io/qwik-city";
+import {
+  getConnection,
+  getReservationsForDate,
+  getSpots,
+  reserveSpot,
+  cancelReservation,
+} from "~/services/spacetimedb";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * GET /api/v1/reservations?date=YYYY-MM-DD
+ * List all reservations for a given date.
+ */
+export const onGet: RequestHandler = async ({ query, json }) => {
+  const date = query.get("date");
+  if (!date || !DATE_RE.test(date)) {
+    json(400, {
+      error: "Bad Request",
+      message: "Query parameter 'date' is required (YYYY-MM-DD)",
+    });
+    return;
+  }
+
+  try {
+    await getConnection();
+    const reservations = getReservationsForDate(date);
+    const spots = getSpots();
+    const spotById = new Map(spots.map((s) => [s.id, s.name]));
+
+    json(200, {
+      date,
+      reservations: reservations.map((r) => ({
+        spotId: r.spotId,
+        spotName: spotById.get(r.spotId) ?? null,
+        occupant: r.occupant,
+      })),
+      count: reservations.length,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    json(500, { error: "Internal Server Error", message });
+  }
+};
+
+/**
+ * POST /api/v1/reservations
+ * Reserve a specific spot.
+ * Body: { spotId: number, date: string, occupant: string }
+ */
+export const onPost: RequestHandler = async ({ request, json }) => {
+  let body: { spotId?: number; date?: string; occupant?: string };
+  try {
+    body = await request.json();
+  } catch {
+    json(400, { error: "Bad Request", message: "Invalid JSON body" });
+    return;
+  }
+
+  const { spotId, date, occupant } = body;
+  if (typeof spotId !== "number" || !date || !occupant?.trim()) {
+    json(400, {
+      error: "Bad Request",
+      message:
+        "Body must include 'spotId' (number), 'date' (YYYY-MM-DD), and 'occupant' (non-empty string)",
+    });
+    return;
+  }
+  if (!DATE_RE.test(date)) {
+    json(400, {
+      error: "Bad Request",
+      message: "'date' must be in YYYY-MM-DD format",
+    });
+    return;
+  }
+
+  try {
+    await getConnection();
+    await reserveSpot(spotId, date, occupant.trim());
+
+    const spots = getSpots();
+    const spotName = spots.find((s) => s.id === spotId)?.name ?? null;
+
+    json(201, {
+      success: true,
+      spotId,
+      spotName,
+      date,
+      occupant: occupant.trim(),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    if (
+      message.includes("already reserved") ||
+      message.includes("does not exist")
+    ) {
+      json(409, { error: "Conflict", message });
+    } else {
+      json(500, { error: "Internal Server Error", message });
+    }
+  }
+};
+
+/**
+ * DELETE /api/v1/reservations
+ * Cancel a reservation.
+ * Body: { spotId: number, date: string, occupant: string }
+ */
+export const onDelete: RequestHandler = async ({ request, json }) => {
+  let body: { spotId?: number; date?: string; occupant?: string };
+  try {
+    body = await request.json();
+  } catch {
+    json(400, { error: "Bad Request", message: "Invalid JSON body" });
+    return;
+  }
+
+  const { spotId, date, occupant } = body;
+  if (typeof spotId !== "number" || !date || !occupant?.trim()) {
+    json(400, {
+      error: "Bad Request",
+      message:
+        "Body must include 'spotId' (number), 'date' (YYYY-MM-DD), and 'occupant' (non-empty string)",
+    });
+    return;
+  }
+  if (!DATE_RE.test(date)) {
+    json(400, {
+      error: "Bad Request",
+      message: "'date' must be in YYYY-MM-DD format",
+    });
+    return;
+  }
+
+  try {
+    await getConnection();
+    await cancelReservation(spotId, date, occupant.trim());
+
+    json(200, { success: true, spotId, date });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    if (
+      message.includes("No reservation found") ||
+      message.includes("Only ")
+    ) {
+      json(409, { error: "Conflict", message });
+    } else {
+      json(500, { error: "Internal Server Error", message });
+    }
+  }
+};

--- a/src/routes/api/v1/reservations/quick/index.test.ts
+++ b/src/routes/api/v1/reservations/quick/index.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/services/spacetimedb", () => ({
+  getConnection: vi.fn(),
+  getSpotsForDate: vi.fn(),
+  quickReserve: vi.fn(),
+  waitForDataSync: vi.fn(),
+}));
+
+import { onPost } from "./index";
+import {
+  getConnection,
+  getSpotsForDate,
+  quickReserve,
+  waitForDataSync,
+} from "~/services/spacetimedb";
+
+const mockGetConnection = vi.mocked(getConnection);
+const mockGetSpotsForDate = vi.mocked(getSpotsForDate);
+const mockQuickReserve = vi.mocked(quickReserve);
+const mockWaitForDataSync = vi.mocked(waitForDataSync);
+
+function makeEvent(body: any, parseError = false) {
+  return {
+    request: {
+      json: parseError
+        ? vi.fn().mockRejectedValue(new SyntaxError("bad json"))
+        : vi.fn().mockResolvedValue(body),
+    },
+    json: vi.fn(),
+  } as any;
+}
+
+describe("POST /api/v1/reservations/quick", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConnection.mockResolvedValue({} as any);
+    mockWaitForDataSync.mockResolvedValue(undefined);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const event = makeEvent(null, true);
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(400, {
+      error: "Bad Request",
+      message: "Invalid JSON body",
+    });
+  });
+
+  it("returns 400 when date is missing", async () => {
+    const event = makeEvent({ occupant: "Alice" });
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns 400 when occupant is empty", async () => {
+    const event = makeEvent({ date: "2025-06-15", occupant: "" });
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns 400 for invalid date format", async () => {
+    const event = makeEvent({ date: "June 15", occupant: "Alice" });
+    await onPost(event);
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        message: "'date' must be in YYYY-MM-DD format",
+      }),
+    );
+  });
+
+  it("quick-reserves successfully with spot details", async () => {
+    mockQuickReserve.mockResolvedValue(undefined);
+    mockGetSpotsForDate.mockReturnValue([
+      { spotId: 1, name: "A1", occupant: "Alice", sortOrder: 1 },
+      { spotId: 2, name: "A2", occupant: "", sortOrder: 2 },
+    ]);
+
+    const event = makeEvent({ date: "2025-06-15", occupant: "Alice" });
+    await onPost(event);
+
+    expect(mockQuickReserve).toHaveBeenCalledWith("2025-06-15", "Alice");
+    expect(event.json).toHaveBeenCalledWith(201, {
+      success: true,
+      date: "2025-06-15",
+      occupant: "Alice",
+      spotId: 1,
+      spotName: "A1",
+    });
+  });
+
+  it("returns null spot info when sync times out", async () => {
+    mockQuickReserve.mockResolvedValue(undefined);
+    mockWaitForDataSync.mockRejectedValue(new Error("Data sync timeout"));
+    mockGetSpotsForDate.mockReturnValue([
+      { spotId: 1, name: "A1", occupant: "", sortOrder: 1 },
+    ]);
+
+    const event = makeEvent({ date: "2025-06-15", occupant: "Alice" });
+    await onPost(event);
+
+    expect(event.json).toHaveBeenCalledWith(201, {
+      success: true,
+      date: "2025-06-15",
+      occupant: "Alice",
+      spotId: null,
+      spotName: null,
+    });
+  });
+
+  it("trims occupant whitespace", async () => {
+    mockQuickReserve.mockResolvedValue(undefined);
+    mockGetSpotsForDate.mockReturnValue([]);
+
+    const event = makeEvent({ date: "2025-06-15", occupant: "  Bob  " });
+    await onPost(event);
+
+    expect(mockQuickReserve).toHaveBeenCalledWith("2025-06-15", "Bob");
+  });
+
+  it("returns 409 when occupant already has a reservation", async () => {
+    mockQuickReserve.mockRejectedValue(
+      new Error("You already have a reservation for this date"),
+    );
+
+    const event = makeEvent({ date: "2025-06-15", occupant: "Alice" });
+    await onPost(event);
+
+    expect(event.json).toHaveBeenCalledWith(409, {
+      error: "Conflict",
+      message: "You already have a reservation for this date",
+    });
+  });
+
+  it("returns 409 when no free spots", async () => {
+    mockQuickReserve.mockRejectedValue(new Error("No free spots available"));
+
+    const event = makeEvent({ date: "2025-06-15", occupant: "Alice" });
+    await onPost(event);
+
+    expect(event.json).toHaveBeenCalledWith(409, {
+      error: "Conflict",
+      message: "No free spots available",
+    });
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    mockQuickReserve.mockRejectedValue(new Error("Network error"));
+
+    const event = makeEvent({ date: "2025-06-15", occupant: "Alice" });
+    await onPost(event);
+
+    expect(event.json).toHaveBeenCalledWith(500, {
+      error: "Internal Server Error",
+      message: "Network error",
+    });
+  });
+});

--- a/src/routes/api/v1/reservations/quick/index.ts
+++ b/src/routes/api/v1/reservations/quick/index.ts
@@ -1,0 +1,74 @@
+import type { RequestHandler } from "@builder.io/qwik-city";
+import {
+  getConnection,
+  getSpotsForDate,
+  quickReserve,
+  waitForDataSync,
+} from "~/services/spacetimedb";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * POST /api/v1/reservations/quick
+ * Auto-assign the first available spot for a date.
+ * Body: { date: string, occupant: string }
+ */
+export const onPost: RequestHandler = async ({ request, json }) => {
+  let body: { date?: string; occupant?: string };
+  try {
+    body = await request.json();
+  } catch {
+    json(400, { error: "Bad Request", message: "Invalid JSON body" });
+    return;
+  }
+
+  const { date, occupant } = body;
+  if (!date || !occupant?.trim()) {
+    json(400, {
+      error: "Bad Request",
+      message:
+        "Body must include 'date' (YYYY-MM-DD) and 'occupant' (non-empty string)",
+    });
+    return;
+  }
+  if (!DATE_RE.test(date)) {
+    json(400, {
+      error: "Bad Request",
+      message: "'date' must be in YYYY-MM-DD format",
+    });
+    return;
+  }
+
+  try {
+    await getConnection();
+    await quickReserve(date, occupant.trim());
+
+    // Wait for subscription to sync the new reservation into the cache
+    try {
+      await waitForDataSync();
+    } catch {
+      // Timeout is non-fatal — we still return success, just without spot details
+    }
+
+    const spots = getSpotsForDate(date);
+    const assigned = spots.find((s) => s.occupant === occupant.trim());
+
+    json(201, {
+      success: true,
+      date,
+      occupant: occupant.trim(),
+      spotId: assigned?.spotId ?? null,
+      spotName: assigned?.name ?? null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    if (
+      message.includes("already have a reservation") ||
+      message.includes("No free spots")
+    ) {
+      json(409, { error: "Conflict", message });
+    } else {
+      json(500, { error: "Internal Server Error", message });
+    }
+  }
+};

--- a/src/routes/api/v1/spots/index.test.ts
+++ b/src/routes/api/v1/spots/index.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/services/spacetimedb", () => ({
+  getConnection: vi.fn(),
+  getSpotsForDate: vi.fn(),
+  getFreeCount: vi.fn(),
+}));
+
+import { onGet } from "./index";
+import {
+  getConnection,
+  getSpotsForDate,
+  getFreeCount,
+} from "~/services/spacetimedb";
+
+const mockGetConnection = vi.mocked(getConnection);
+const mockGetSpotsForDate = vi.mocked(getSpotsForDate);
+const mockGetFreeCount = vi.mocked(getFreeCount);
+
+function makeEvent(queryParams: Record<string, string> = {}) {
+  const event: any = {
+    query: {
+      get: (key: string) => queryParams[key] ?? null,
+    },
+    json: vi.fn(),
+  };
+  return event;
+}
+
+describe("GET /api/v1/spots", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConnection.mockResolvedValue({} as any);
+  });
+
+  it("returns 400 when date is missing", async () => {
+    const event = makeEvent();
+    await onGet(event);
+
+    expect(event.json).toHaveBeenCalledWith(400, {
+      error: "Bad Request",
+      message: "Query parameter 'date' is required (YYYY-MM-DD)",
+    });
+  });
+
+  it("returns 400 when date format is invalid", async () => {
+    const event = makeEvent({ date: "01-01-2025" });
+    await onGet(event);
+
+    expect(event.json).toHaveBeenCalledWith(400, {
+      error: "Bad Request",
+      message: "Query parameter 'date' is required (YYYY-MM-DD)",
+    });
+  });
+
+  it("returns 400 for partial date format", async () => {
+    const event = makeEvent({ date: "2025-1-1" });
+    await onGet(event);
+
+    expect(event.json).toHaveBeenCalledWith(
+      400,
+      expect.objectContaining({
+        error: "Bad Request",
+      }),
+    );
+  });
+
+  it("returns spots with availability info", async () => {
+    mockGetSpotsForDate.mockReturnValue([
+      { spotId: 1, name: "A1", occupant: "Alice", sortOrder: 1 },
+      { spotId: 2, name: "A2", occupant: "", sortOrder: 2 },
+    ]);
+    mockGetFreeCount.mockReturnValue(1);
+
+    const event = makeEvent({ date: "2025-06-15" });
+    await onGet(event);
+
+    expect(event.json).toHaveBeenCalledWith(200, {
+      date: "2025-06-15",
+      spots: [
+        { spotId: 1, name: "A1", occupant: "Alice", available: false },
+        { spotId: 2, name: "A2", occupant: null, available: true },
+      ],
+      total: 2,
+      available: 1,
+    });
+  });
+
+  it("returns 500 on connection error", async () => {
+    mockGetConnection.mockRejectedValue(new Error("Connection failed"));
+
+    const event = makeEvent({ date: "2025-06-15" });
+    await onGet(event);
+
+    expect(event.json).toHaveBeenCalledWith(500, {
+      error: "Internal Server Error",
+      message: "Connection failed",
+    });
+  });
+});

--- a/src/routes/api/v1/spots/index.ts
+++ b/src/routes/api/v1/spots/index.ts
@@ -1,0 +1,40 @@
+import type { RequestHandler } from "@builder.io/qwik-city";
+import {
+  getConnection,
+  getSpotsForDate,
+  getFreeCount,
+} from "~/services/spacetimedb";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export const onGet: RequestHandler = async ({ query, json }) => {
+  const date = query.get("date");
+  if (!date || !DATE_RE.test(date)) {
+    json(400, {
+      error: "Bad Request",
+      message: "Query parameter 'date' is required (YYYY-MM-DD)",
+    });
+    return;
+  }
+
+  try {
+    await getConnection();
+    const spots = getSpotsForDate(date);
+    const freeCount = getFreeCount(date);
+
+    json(200, {
+      date,
+      spots: spots.map((s) => ({
+        spotId: s.spotId,
+        name: s.name,
+        occupant: s.occupant || null,
+        available: !s.occupant,
+      })),
+      total: spots.length,
+      available: freeCount,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    json(500, { error: "Internal Server Error", message });
+  }
+};

--- a/src/services/api-auth.test.ts
+++ b/src/services/api-auth.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { validateApiKey } from "./api-auth";
+
+function makeEnv(apiKeys?: string) {
+  return {
+    get: (key: string) => (key === "API_KEYS" ? apiKeys : undefined),
+  };
+}
+
+describe("validateApiKey", () => {
+  it("rejects missing Authorization header", () => {
+    const result = validateApiKey(makeEnv("sk-test-key"), null);
+    expect(result).toEqual({
+      valid: false,
+      error: "Missing Authorization header",
+    });
+  });
+
+  it("rejects malformed Authorization header", () => {
+    const result = validateApiKey(makeEnv("sk-test-key"), "Basic abc123");
+    expect(result).toEqual({
+      valid: false,
+      error: "Invalid Authorization header format. Expected: Bearer <token>",
+    });
+  });
+
+  it("rejects empty Bearer token", () => {
+    const result = validateApiKey(makeEnv("sk-test-key"), "Bearer ");
+    expect(result).toEqual({
+      valid: false,
+      error: "Invalid Authorization header format. Expected: Bearer <token>",
+    });
+  });
+
+  it("rejects when API_KEYS env is not configured", () => {
+    const result = validateApiKey(makeEnv(undefined), "Bearer sk-test-key");
+    expect(result).toEqual({
+      valid: false,
+      error: "API keys not configured on server",
+    });
+  });
+
+  it("rejects when API_KEYS env is empty string", () => {
+    const result = validateApiKey(makeEnv(""), "Bearer sk-test-key");
+    expect(result).toEqual({
+      valid: false,
+      error: "API keys not configured on server",
+    });
+  });
+
+  it("rejects invalid API key", () => {
+    const result = validateApiKey(makeEnv("sk-valid-key"), "Bearer sk-wrong");
+    expect(result).toEqual({
+      valid: false,
+      error: "Invalid API key",
+    });
+  });
+
+  it("accepts a valid API key", () => {
+    const result = validateApiKey(makeEnv("sk-test-key"), "Bearer sk-test-key");
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("accepts any valid key from comma-separated list", () => {
+    const env = makeEnv("sk-key-1, sk-key-2, sk-key-3");
+    expect(validateApiKey(env, "Bearer sk-key-1")).toEqual({ valid: true });
+    expect(validateApiKey(env, "Bearer sk-key-2")).toEqual({ valid: true });
+    expect(validateApiKey(env, "Bearer sk-key-3")).toEqual({ valid: true });
+    expect(validateApiKey(env, "Bearer sk-key-4")).toEqual({
+      valid: false,
+      error: "Invalid API key",
+    });
+  });
+
+  it("handles whitespace in API_KEYS value", () => {
+    const env = makeEnv("  sk-key-1 ,  sk-key-2  ");
+    expect(validateApiKey(env, "Bearer sk-key-1")).toEqual({ valid: true });
+    expect(validateApiKey(env, "Bearer sk-key-2")).toEqual({ valid: true });
+  });
+
+  it("rejects key that is a prefix of a valid key (timing-safe)", () => {
+    const result = validateApiKey(makeEnv("sk-long-key"), "Bearer sk-long");
+    expect(result).toEqual({ valid: false, error: "Invalid API key" });
+  });
+
+  it("rejects key that is a superstring of a valid key", () => {
+    const result = validateApiKey(makeEnv("sk-short"), "Bearer sk-short-extra");
+    expect(result).toEqual({ valid: false, error: "Invalid API key" });
+  });
+});

--- a/src/services/api-auth.ts
+++ b/src/services/api-auth.ts
@@ -1,0 +1,58 @@
+/**
+ * API key validation for AI agent access.
+ *
+ * Keys are stored in the API_KEYS environment variable (comma-separated).
+ * Agents authenticate via the Authorization: Bearer <key> header.
+ */
+
+import { timingSafeEqual } from "crypto";
+
+interface EnvGetter {
+  get(key: string): string | undefined;
+}
+
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function validateApiKey(
+  env: EnvGetter,
+  authHeader: string | null,
+): ValidationResult {
+  if (!authHeader) {
+    return { valid: false, error: "Missing Authorization header" };
+  }
+
+  const match = authHeader.match(/^Bearer\s+(\S+)$/);
+  if (!match) {
+    return {
+      valid: false,
+      error: "Invalid Authorization header format. Expected: Bearer <token>",
+    };
+  }
+
+  const token = match[1];
+  const keysRaw = env.get("API_KEYS");
+  if (!keysRaw) {
+    return { valid: false, error: "API keys not configured on server" };
+  }
+
+  const validKeys = keysRaw
+    .split(",")
+    .map((k) => k.trim())
+    .filter(Boolean);
+
+  const tokenBuf = Buffer.from(token);
+  const isValid = validKeys.some((key) => {
+    const keyBuf = Buffer.from(key);
+    if (tokenBuf.length !== keyBuf.length) return false;
+    return timingSafeEqual(tokenBuf, keyBuf);
+  });
+
+  if (!isValid) {
+    return { valid: false, error: "Invalid API key" };
+  }
+
+  return { valid: true };
+}

--- a/src/services/spacetimedb.ts
+++ b/src/services/spacetimedb.ts
@@ -215,3 +215,27 @@ export async function quickReserve(
   const conn = await getConnection();
   await conn.reducers.quickReserve({ date, occupant });
 }
+
+/**
+ * Wait for the next data sync from SpacetimeDB subscriptions.
+ * Useful after mutations to ensure cached data reflects the change.
+ */
+export function waitForDataSync(timeoutMs = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = { unsub: () => {} };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup.unsub();
+      reject(new Error("Data sync timeout"));
+    }, timeoutMs);
+    cleanup.unsub = onDataChange(() => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanup.unsub();
+      resolve();
+    });
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~": resolve(__dirname, "src"),
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds authenticated `/api/v1/` REST endpoints for AI agents to manage parking reservations
- Bearer token auth middleware with timing-safe key validation (`API_KEYS` env var)
- Endpoints: `GET /spots`, `GET /reservations`, `POST /reservations`, `DELETE /reservations`, `POST /reservations/quick`
- New `waitForDataSync` helper for post-mutation cache consistency

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/spots?date=YYYY-MM-DD` | List spots with availability |
| GET | `/api/v1/reservations?date=YYYY-MM-DD` | List reservations for a date |
| POST | `/api/v1/reservations` | Reserve a specific spot |
| DELETE | `/api/v1/reservations` | Cancel a reservation |
| POST | `/api/v1/reservations/quick` | Auto-assign first available spot |

## Test plan
- [ ] Set `API_KEYS` env var and verify auth middleware rejects missing/invalid tokens
- [ ] Verify `GET /api/v1/spots?date=2026-03-27` returns spot list with availability
- [ ] Verify `POST /api/v1/reservations` creates reservation and returns 201
- [ ] Verify `POST /api/v1/reservations/quick` auto-assigns a spot and returns 201
- [ ] Verify `DELETE /api/v1/reservations` cancels and returns 200
- [ ] Verify 409 responses for conflicts (duplicate reservation, no free spots)
- [ ] Verify 400 responses for invalid input (bad date format, missing fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)